### PR TITLE
Add automerge config

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        if: github.actor == "dependabot"
         uses: 'pascalgn/automerge-action@v0.15.5'
+        if: ${{ github.actor == "dependabot" }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           MERGE_LABELS: 'dependencies'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,12 +19,12 @@ on:
   status: {}
 jobs:
   automerge:
+    if: github.actor == 'dependabot'
     runs-on: ubuntu-latest
     steps:
       - id: automerge
         name: automerge
         uses: 'pascalgn/automerge-action@v0.15.5'
-        if: ${{ github.actor == "dependabot" }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           MERGE_LABELS: 'dependencies'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,30 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - id: automerge
+        name: automerge
+        if: github.actor == "dependabot"
+        uses: 'pascalgn/automerge-action@v0.15.5'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          MERGE_LABELS: 'dependencies'


### PR DESCRIPTION
This PR adds an `automerge` github action that _should_ only run on dependabot PRs that will auto-merge them once the build is successful.